### PR TITLE
[API for mycat] 번역 입력&가져오기

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ cert
 *.json
 *.swp
 *.txt
+.idea/

--- a/detourserver.py
+++ b/detourserver.py
@@ -324,7 +324,7 @@ def inputTranslation():
     original_text_id = request.form['original_text_id']
 
     contributor_media = request.form['contributor_media']
-    contributor_text_id = request.form['contributor_text_id']
+    contributor_text_id = request.form.get('contributor_text_id', None)
     target_lang = request.form['target_lang']
     target_text = request.form['target_text']
 
@@ -335,7 +335,7 @@ def inputTranslation():
     if request.form.get('contributor_external_id') is not None:
         contributor_id_external = int(request.form.get('contributor_external_id'))
     else:
-        contributor_id_external = int(session.get('id_external'))
+        contributor_id_external = session.get('id_external', None)
 
     print(contributor_id_external)
 
@@ -351,6 +351,75 @@ def inputTranslation():
 
     code, target_text_id, original_contributor_id, original_contributor_media, original_contributor_text_id, origin_lang, origin_text, origin_tag, origin_where_contributed, origin_id_external = sentenceObj.inputTranslation(conn, original_text_id, contributor_id, target_text, target_lang, where_contribute, tags)
 
+    if code == 0:
+        if original_contributor_id == 0:
+            is_ok = userObj.getPoint(conn, contributor_media, contributor_id_external, origin_lang, target_lang, 1.1, text_id=contributor_text_id)
+            is_ok = translator.writeActionLog(conn, contributor_id, None, origin_lang, target_lang, 'origin_contribute', 1, 0)
+            is_ok = translator.writeActionLog(conn, contributor_id, None, origin_lang, target_lang, 'target_contribute', 1, 0)
+            is_ok = translator.writeActionLog(conn, contributor_id, None, origin_lang, target_lang, 'point_issue', 0, 0.1)
+            is_ok = translator.writeActionLog(conn, contributor_id, None, origin_lang, target_lang, 'point_issue', 0, 1)
+
+        else:
+            is_ok = userObj.getPoint(conn, original_contributor_media, origin_id_external, origin_lang, target_lang, 0.1, text_id=original_contributor_text_id)
+            is_ok = userObj.getPoint(conn, contributor_media, contributor_id_external, origin_lang, target_lang, 1, text_id=contributor_text_id)
+            is_ok = translator.writeActionLog(conn, contributor_id, None, origin_lang, target_lang, 'target_contribute', 1, 0)
+            is_ok = translator.writeActionLog(conn, original_contributor_id, None, origin_lang, target_lang, 'point_issue', 0, 0.1)
+            is_ok = translator.writeActionLog(conn, contributor_id, None, origin_lang, target_lang, 'point_issue', 0, 1)
+
+        ret_data = translator.viewOneCompleteUnit(conn, target_text_id)
+
+        if ret_data is not None:
+            return make_response(json.jsonify(**ret_data), 200)
+        else:
+            return make_response(json.jsonify(result="nothing"), 200)
+
+    else:
+        return make_response(json.jsonify(result="nothing"), 200)
+
+@app.route('/api/v1/translation/mycat', methods=['POST'])
+def inputTranslation_from_mycat():
+    """
+    original_text_id: Int
+    contributor_media: mycat
+    contributor_email: 번역가 이메일
+    tags: mycat에서 문서 입력시 받는 tags
+    target_lang: 번역문 언어
+    target_text:String, 번역문
+    where_contribute:mycat
+    :return:
+    """
+    conn = connect_db()
+    original_text_id = request.form.get('original_text_id', None)
+
+    contributor_media = request.form.get('contributor_media', None)
+    contributor_text_id = request.form.get('contributor_text_id', None)
+    target_lang = request.form.get('target_lang', None)
+    target_text = request.form.get('target_text', None)
+    where_contribute = request.form.get('where_contribute', None)
+
+    tags = request.form.get('tags', None)
+
+    if None in [original_text_id, contributor_media, contributor_text_id, target_lang, target_text, where_contribute]:
+        error = {
+            "code": 2301,
+            "type": "NullValue",
+            "message": "something not entered. please check source_id and comment."
+        }
+        return make_response(json.jsonify(error=error), 422)
+
+    sentenceObj = Sentences()
+    userObj = Users()
+
+    contributor_user_id_obj = userObj._getId(conn, contributor_media, id_external=None, text_id=contributor_text_id)
+    contributor_id = 0
+    if contributor_user_id_obj is None or len(contributor_user_id_obj) < 1:
+        contributor_id = 0
+    else:
+        contributor_id = contributor_user_id_obj['id']
+
+    code, target_text_id, original_contributor_id, original_contributor_media, original_contributor_text_id, origin_lang, origin_text, origin_tag, origin_where_contributed, origin_id_external = sentenceObj.inputTranslation(conn, original_text_id, contributor_id, target_text, target_lang, where_contribute, tags)
+
+    contributor_id_external = contributor_user_id_obj['id_external']
     if code == 0:
         if original_contributor_id == 0:
             is_ok = userObj.getPoint(conn, contributor_media, contributor_id_external, origin_lang, target_lang, 1.1, text_id=contributor_text_id)

--- a/sentence.py
+++ b/sentence.py
@@ -52,8 +52,10 @@ class Sentences(object):
             cursor.execute(query, (contributor_id, language, text, tags, text, where_contributed, ))
 
         except pymysql.err.IntegrityError:
+            cursor.execute("""SELECT id as original_text_id FROM langchain.origin_texts WHERE text=%s;""", (text, ))
+            ret = cursor.fetchone()
             print("Duplicate sentence {}".format(text))
-            return 1, None
+            return 1, ret['original_text_id']
 
         except:
             traceback.print_exc()

--- a/translator.py
+++ b/translator.py
@@ -457,6 +457,7 @@ class Translator(object):
 
         for idx, sentence in enumerate(splitted_sentence):
             ret = self.findTranslation(conn, source_lang, target_lang, sentence)
+            original_text_id = ret[1]
 
             # 0: True, 
             # 1: original_text_id
@@ -476,18 +477,18 @@ class Translator(object):
 
             else:
                 sentenceCtrlObj = SentenceCtrl()
-                code, original_sentence_id = sentenceCtrlObj._inputOriginalSentence(conn, order_user_id, source_lang, sentence, where_contributed, tags)
+                code, original_text_id = sentenceCtrlObj._inputOriginalSentence(conn, order_user_id, source_lang, sentence, where_contributed, tags)
                 if code == 0:
                     is_ok = self.writeActionLog(conn, order_user_id, 0, source_lang, target_lang, 'origin_contribute', 1, 0)
                 elif code == 1:
                     # Duplicate origin lang contribution
                     # 태그 로직 반영되면 변경예정
                     pass
-
                 else:
                     return False, None
 
         is_ok, result = self.doWorkSingle(source_lang, target_lang, sentences)
+        result['original_text_id'] = original_text_id
 
         splitted_translated_sentence = []
         if (source_lang == 'ko' and target_lang == 'en') or (source_lang == 'en' and target_lang == 'ko'):
@@ -515,7 +516,6 @@ class Translator(object):
                 )
 
         is_ok = self.increaseCallCnt(conn, user_id)
-
         return is_ok, result
 
 

--- a/translator.py
+++ b/translator.py
@@ -446,6 +446,7 @@ class Translator(object):
         
         userCtrl = UserCtrl()
         ret = userCtrl._getId(conn, media, order_user)
+
         order_user_id = 0
         if ret is None or len(ret) < 1:
             order_user_id = 0

--- a/users.py
+++ b/users.py
@@ -4,6 +4,17 @@ class Users(object):
     def _getId(self, conn, media, id_external, text_id=None):
         cursor = conn.cursor()
 
+        if media == 'mycat':
+            if id_external and text_id is None:
+                email = id_external
+            else:
+                email = text_id
+            query = """SELECT u.id, ru.text_id, eos_id, 'mycat' as media, languages, source_lang, target_lang, chat_id, last_original_text_id, point, id_external
+                       FROM real_users ru JOIN users u ON u.real_user_id = ru.id WHERE ru.text_id=%s;"""
+            cursor.execute(query, (email, ))
+            ret = cursor.fetchone()
+            return ret
+
         # Will be activated
         #query = """
         #    SELECT * FROM users
@@ -97,13 +108,13 @@ class Users(object):
                   , "eos_id": ret['eos_id']
                   , "media": ret['media']
                   , "text_id": ret['text_id']
-                  , "languages": ret['languages']
-                  , "source_lang": ret['source_lang']
-                  , "target_lang": ret['target_lang']
-                  , "chat_id": ret['chat_id']
-                  , "last_original_text_id": ret['last_original_text_id']
+                  , "languages": ret.get('languages', None)
+                  , "source_lang": ret.get('source_lang', None)
+                  , "target_lang": ret.get('target_lang', None)
+                  , "chat_id": ret.get('chat_id', None)
+                  , "last_original_text_id": ret.get('last_original_text_id', None)
                   , "point": self._getPoint(conn, ret['id'])
-                  , "id_external": ret['id_external']
+                  , "id_external": ret.get('id_external', None)
                     }
 
     def getPoint(self, conn, media, id_external, source_lang, target_lang, point, text_id=None):


### PR DESCRIPTION
- 번역을 가져올 때 original_text_id도 응답에 포함되도록 수정하기
- 번역을 입력할 때 contributor_text_id 없어도 처리되도록 수정하기
- 사용자 검색할 때, media=mycat이면 id_external이나 text_id에 이메일 있는 변수로 사용자 검색하기
